### PR TITLE
Fix OOM at container level issue

### DIFF
--- a/manifest-unversioned.yml
+++ b/manifest-unversioned.yml
@@ -5,7 +5,7 @@ memory: 512M
 env:
     SPRING_PROFILES_ACTIVE: cloud
     JAVA_OPTS: -Djava.security.egd=file:///dev/urandom
-    JBP_CONFIG_OPEN_JDK_JRE: '[memory_calculator: { memory_sizes: { metaspace: 100m }}]'
+    JBP_CONFIG_OPEN_JDK_JRE: '[memory_calculator: { memory_sizes: { metaspace: 100m }, memory_heuristics: {metaspace: 10, heap: 65, native: 20, permgen: 10, stack: 5}  }]'
 applications:
 - name: accounts
   random-route: true


### PR DESCRIPTION
I've been monitoring these new memory heuristics for a few days, bumping up the "native" memory, and these tend to leave enough free RAM in the diego container such that with PCF 1.6.15+ these services will stay up indefinitely without diego terminating them every few hours.
